### PR TITLE
Fix DB connection string

### DIFF
--- a/AutomaticStockTrader.Repository/Configuration/DatabaseConfig.cs
+++ b/AutomaticStockTrader.Repository/Configuration/DatabaseConfig.cs
@@ -4,6 +4,6 @@
     {
         public string Db_Connection_String { get; set; }
 
-        public const string DEFAULT_CONNECTION_STRING = @"Data Source=Application;Mode=Memory;Cache=Shared";
+        public const string DEFAULT_CONNECTION_STRING = @"Data Source=Application.db;Cache=Shared";
     }
 }

--- a/AutomaticStockTrader.Repository/Configuration/DatabaseConfig.cs
+++ b/AutomaticStockTrader.Repository/Configuration/DatabaseConfig.cs
@@ -4,6 +4,6 @@
     {
         public string Db_Connection_String { get; set; }
 
-        public const string DEFAULT_CONNECTION_STRING = @"Data Source=Application.db;Cache=Shared";
+        public const string DEFAULT_CONNECTION_STRING = @"Data Source=Application;Mode=Memory;Cache=Shared";
     }
 }

--- a/AutomaticStockTrader.Tests/TrackingRepositoryTests.cs
+++ b/AutomaticStockTrader.Tests/TrackingRepositoryTests.cs
@@ -1,5 +1,7 @@
 ﻿using AutomaticStockTrader.Repository;
+using AutomaticStockTrader.Repository.Configuration;
 using AutomaticStockTrader.Repository.Models;
+using Microsoft.Data.Sqlite;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using System;
 using System.Collections.Generic;
@@ -25,7 +27,6 @@ namespace AutomaticStockTrader.Tests
             _context = new StockContext();
             _context.Database.EnsureDeleted();
             _context.Database.EnsureCreated();
-
 
             _repo = new TrackingRepository(_context);
         }

--- a/Dockerfile
+++ b/Dockerfile
@@ -20,4 +20,8 @@ RUN dotnet publish "AutomaticStockTrader.csproj" -c Release -o /app/publish
 FROM base AS final
 WORKDIR /app
 COPY --from=publish /app/publish .
+
+RUN chown -R www-data /app
+USER www-data
+
 ENTRYPOINT ["dotnet", "AutomaticStockTrader.dll"]


### PR DESCRIPTION
For some reason, the DO app platform is not letting us write the application.db file to disk so we are getting errors on startup. We can fix this by moving the sql lite data store in memory.