### PR TITLE
Refactor order and Alpaca config

### DIFF
--- a/AutomaticStockTrader.Core/Alpaca/IAlpacaClient.cs
+++ b/AutomaticStockTrader.Core/Alpaca/IAlpacaClient.cs
@@ -1,4 +1,4 @@
-﻿using AutomaticStockTrader.Domain;
+using AutomaticStockTrader.Domain;
 using System;
 using System.Collections.Generic;
 using System.Threading.Tasks;
@@ -11,9 +11,8 @@ namespace AutomaticStockTrader.Core.Alpaca
         public Task DisconnectStreamApis();
         public void AddPendingMinuteAggSubscription(string stockSymbol, Action<StockInput> action);
         public void SubscribeToMinuteAgg();
-        public void SubscribeToTradeUpdates(Action<CompletedOrder> action);
-        public Task PlaceOrder(StrategysStock postion, Order order);
-        public Task EnsurePostionCleared(StrategysStock postion);
+        public void SubscribeToTradeUpdates(Action<Order> action);
+        public Task PlaceOrder(Order order);
         public Task<decimal> GetTotalEquity();
         public Task<IList<StockInput>> GetStockData(string stockSymbol, TradingFrequency aggUnits, int lookBack = 1000);
         public Task<IEnumerable<DateTime>> GetAllTradingHolidays(DateTime? start = null, DateTime? end = null);

--- a/AutomaticStockTrader.Core/ServiceCollectionExtentions.cs
+++ b/AutomaticStockTrader.Core/ServiceCollectionExtentions.cs
@@ -17,6 +17,7 @@ using Quartz;
 using Quartz.Impl.Calendar;
 using Microsoft.Extensions.Configuration;
 using AutomaticStockTrader.Repository.Configuration;
+using AutomaticStockTrader.Core.Traders;
 
 namespace AutomaticStockTrader.Core
 {

--- a/AutomaticStockTrader.Core/Strategies/StrategyHandler.cs
+++ b/AutomaticStockTrader.Core/Strategies/StrategyHandler.cs
@@ -90,13 +90,14 @@ namespace AutomaticStockTrader.Core.Strategies
             {
                 var order = new Order
                 {
+                    StockSymbol = stockStrategy.StockSymbol,
                     SharesBought = currentPosition.NumberOfShares * (-1),
                     MarketPrice = marketPrice,
                     OrderPlacedTime = DateTime.UtcNow
                 };
 
                 await _trackingRepository.AddPendingOrder(stockStrategy, order);
-                await _alpacaClient.PlaceOrder(stockStrategy, order);
+                await _alpacaClient.PlaceOrder(order);
             }
         }
 
@@ -111,13 +112,14 @@ namespace AutomaticStockTrader.Core.Strategies
             {
                 var order = new Order
                 {
+                    StockSymbol = stockStrategy.StockSymbol,
                     SharesBought = sharesNeeded,
                     MarketPrice = marketPrice,
                     OrderPlacedTime = DateTime.UtcNow
                 };
 
                 await _trackingRepository.AddPendingOrder(stockStrategy, order);
-                await _alpacaClient.PlaceOrder(stockStrategy, order);
+                await _alpacaClient.PlaceOrder(order);
             }
         }
 

--- a/AutomaticStockTrader.Core/Traders/CloseStreamingTrader.cs
+++ b/AutomaticStockTrader.Core/Traders/CloseStreamingTrader.cs
@@ -8,7 +8,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
 
-namespace AutomaticStockTrader.Core
+namespace AutomaticStockTrader.Core.Traders
 {
     public class CloseStreamingTrader : IJob
     {
@@ -43,8 +43,9 @@ namespace AutomaticStockTrader.Core
                 if(position.NumberOfShares > 0)
                 {
                     var marketPriceTask = _alpacaClient.GetStockData(position.StockSymbol, strategy.StockStrategy.TradingFrequency, 1);
-                    await _alpacaClient.PlaceOrder(strategy.StockStrategy, new Domain.Order
+                    await _alpacaClient.PlaceOrder(new Domain.Order
                     {
+                        StockSymbol = strategy.StockStrategy.StockSymbol,
                         MarketPrice = (await marketPriceTask).FirstOrDefault()?.ClosingPrice ?? 0,
                         OrderPlacedTime = DateTime.UtcNow,
                         SharesBought = position.NumberOfShares * (-1)

--- a/AutomaticStockTrader.Core/Traders/ScheduledTrader.cs
+++ b/AutomaticStockTrader.Core/Traders/ScheduledTrader.cs
@@ -8,7 +8,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
 
-namespace AutomaticStockTrader.Core
+namespace AutomaticStockTrader.Core.Traders
 {
     public class ScheduledTrader : IJob
     {

--- a/AutomaticStockTrader.Core/Traders/StartStreamingTrader.cs
+++ b/AutomaticStockTrader.Core/Traders/StartStreamingTrader.cs
@@ -8,7 +8,7 @@ using AutomaticStockTrader.Repository;
 using Microsoft.Extensions.Logging;
 using Quartz;
 
-namespace AutomaticStockTrader
+namespace AutomaticStockTrader.Core.Traders
 {
     public class StartStreamingTrader : IJob
     {

--- a/AutomaticStockTrader.Domain/Domain.cs
+++ b/AutomaticStockTrader.Domain/Domain.cs
@@ -11,14 +11,10 @@ namespace AutomaticStockTrader.Domain
 
     public record Order
     {
+        public string StockSymbol { get; init; }
         public DateTime OrderPlacedTime { get; init; }
         public long SharesBought { get; init; }
         public decimal MarketPrice { get; init; }
-    }
-
-    public record CompletedOrder : Order
-    {
-        public string StockSymbol { get; init; }
     }
 
     public record StrategysStock

--- a/AutomaticStockTrader.Repository/ITrackingRepository.cs
+++ b/AutomaticStockTrader.Repository/ITrackingRepository.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Threading.Tasks;
 
@@ -7,7 +7,7 @@ namespace AutomaticStockTrader.Repository
     public interface ITrackingRepository : IDisposable
     {
         public Task AddPendingOrder(Domain.StrategysStock postion, Domain.Order order);
-        public Task CompleteOrder(Domain.CompletedOrder completedOrder);
+        public Task CompleteOrder(Domain.Order completedOrder);
         public Task<Domain.Position> GetOrCreateEmptyPosition(Domain.StrategysStock strategysStock);
         public IEnumerable<Domain.Order> GetCompletedOrders(Domain.StrategysStock strategysStock);
     }

--- a/AutomaticStockTrader.Repository/TrackingRepository.cs
+++ b/AutomaticStockTrader.Repository/TrackingRepository.cs
@@ -1,4 +1,4 @@
-﻿using AutomaticStockTrader.Repository.Models;
+using AutomaticStockTrader.Repository.Models;
 using System;
 using System.Collections.Generic;
 using System.Linq;
@@ -30,7 +30,7 @@ namespace AutomaticStockTrader.Repository
             await _context.SaveChangesAsync();
         }
 
-        public async Task CompleteOrder(Domain.CompletedOrder completedOrder)
+        public async Task CompleteOrder(Domain.Order completedOrder)
         {
             var potentialOrders = _context.Orders
                 .Where(x =>

--- a/AutomaticStockTrader.Tests/AlpacaClientTests.cs
+++ b/AutomaticStockTrader.Tests/AlpacaClientTests.cs
@@ -19,7 +19,6 @@ namespace AutomaticStockTrader.Tests
         private Mock<IAlpacaStreamingClient> _mockAlpacaTradingStreamingClient;
         private Mock<IAlpacaDataClient> _mockAlpacaDataClient;
         private Mock<IAlpacaDataStreamingClient> _mockAlpacaDataStreamingClient;
-        private AlpacaConfig _testConfig;
 
         [TestInitialize]
         public void SetUp()
@@ -30,15 +29,7 @@ namespace AutomaticStockTrader.Tests
             _mockAlpacaDataClient = new Mock<IAlpacaDataClient>();
             _mockAlpacaDataStreamingClient = new Mock<IAlpacaDataStreamingClient>();
 
-            _testConfig = new AlpacaConfig
-            {
-                Alpaca_App_Id = "p243ifj23-9fjipwfn4pjinf24e",
-                Alpaca_Secret_Key = "02489gh230gh-93fqenpi",
-                Alpaca_Use_Live_Api = false,
-            };
-
             _alpacaClient = new AlpacaClient(
-                Options.Create(_testConfig),
                 _mockAlpacaTradingClient.Object,
                 _mockAlpacaTradingStreamingClient.Object,
                 _mockAlpacaDataClient.Object,
@@ -49,23 +40,18 @@ namespace AutomaticStockTrader.Tests
         [TestMethod]
         public async Task PlaceOrder_PositiveShares_Buys()
         {
-            var strategyStock = new StrategysStock
-            {
-                StockSymbol = "Foo",
-                Strategy = "Bar",
-                TradingFrequency = TradingFrequency.Year
-            };
             var order = new Order
             {
+                StockSymbol = "Foo",
                 MarketPrice = 12m,
                 OrderPlacedTime = DateTime.Now,
                 SharesBought = 13
             };
 
-            await _alpacaClient.PlaceOrder(strategyStock, order);
+            await _alpacaClient.PlaceOrder(order);
 
             _mockAlpacaTradingClient.Verify(x => x.PostOrderAsync(It.Is<NewOrderRequest>(y =>
-                y.Symbol == strategyStock.StockSymbol &&
+                y.Symbol == order.StockSymbol &&
                 y.Quantity == order.SharesBought &&
                 y.Side == OrderSide.Buy &&
                 y.Type == OrderType.Market &&
@@ -76,23 +62,18 @@ namespace AutomaticStockTrader.Tests
         [TestMethod]
         public async Task PlaceOrder_NegativeShares_Sells()
         {
-            var strategyStock = new StrategysStock
-            {
-                StockSymbol = "Foo",
-                Strategy = "Bar",
-                TradingFrequency = TradingFrequency.Year
-            };
             var order = new Order
             {
+                StockSymbol = "Foo",
                 MarketPrice = 12m,
                 OrderPlacedTime = DateTime.Now,
                 SharesBought = -13
             };
 
-            await _alpacaClient.PlaceOrder(strategyStock, order);
+            await _alpacaClient.PlaceOrder(order);
 
             _mockAlpacaTradingClient.Verify(x => x.PostOrderAsync(It.Is<NewOrderRequest>(y =>
-                y.Symbol == strategyStock.StockSymbol &&
+                y.Symbol == order.StockSymbol &&
                 y.Quantity == order.SharesBought * (-1) &&
                 y.Side == OrderSide.Sell &&
                 y.Type == OrderType.Market &&

--- a/AutomaticStockTrader.Tests/AutomaticStockTrader.Tests.csproj
+++ b/AutomaticStockTrader.Tests/AutomaticStockTrader.Tests.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <TargetFramework>net5.0</TargetFramework>

--- a/AutomaticStockTrader.Tests/Stratagies/LargeStrategiesTests.cs
+++ b/AutomaticStockTrader.Tests/Stratagies/LargeStrategiesTests.cs
@@ -52,7 +52,6 @@ namespace AutomaticStockTrader.Tests.Stategies
             var key = new SecretKey(alpacaConfig.Alpaca_App_Id, alpacaConfig.Alpaca_Secret_Key);
 
             _alpacaClient = new AlpacaClient(
-                Options.Create(alpacaConfig), 
                 env.GetAlpacaTradingClient(key), 
                 env.GetAlpacaStreamingClient(key), 
                 env.GetAlpacaDataClient(key), 
@@ -162,9 +161,9 @@ namespace AutomaticStockTrader.Tests.Stategies
             foreach (var min in testData)
             {
                 _mockAlpacaClient
-                    .Setup(x => x.PlaceOrder(It.Is<StrategysStock>(x => x.StockSymbol == min.StockSymbol), It.IsAny<Order>()))
+                    .Setup(x => x.PlaceOrder(It.Is<Order>(x => x.StockSymbol == min.StockSymbol)))
                     .Callback<StrategysStock, Order>((s, o) =>
-                        _repo.CompleteOrder(new CompletedOrder
+                        _repo.CompleteOrder(new Order
                         {
                             StockSymbol = min.StockSymbol,
                             MarketPrice = o.MarketPrice,

--- a/AutomaticStockTrader.Tests/Stratagies/StrategyHandlerTests.cs
+++ b/AutomaticStockTrader.Tests/Stratagies/StrategyHandlerTests.cs
@@ -72,7 +72,7 @@ namespace AutomaticStockTrader.Tests.Stategies
 
             await _strategyHandler.HandleBuy((decimal)price, strategysStock);
 
-            _mockAlpacaClient.Verify(x => x.PlaceOrder(It.IsAny<StrategysStock>(), It.IsAny<Order>()), Times.Never);
+            _mockAlpacaClient.Verify(x => x.PlaceOrder(It.IsAny<Order>()), Times.Never);
             _mockTrackingRepository.Verify(x => x.AddPendingOrder(It.IsAny<StrategysStock>(), It.IsAny<Order>()), Times.Never);
         }
 
@@ -104,7 +104,7 @@ namespace AutomaticStockTrader.Tests.Stategies
 
             await _strategyHandler.HandleBuy((decimal)price, strategysStock);
 
-            _mockAlpacaClient.Verify(x => x.PlaceOrder(It.IsAny<StrategysStock>(), It.Is<Order>(x => x.SharesBought == shareBought)), Times.Once);
+            _mockAlpacaClient.Verify(x => x.PlaceOrder(It.Is<Order>(x => x.SharesBought == shareBought)), Times.Once);
             _mockTrackingRepository.Verify(x => x.AddPendingOrder(It.IsAny<StrategysStock>(), It.Is<Order>(x => x.SharesBought == shareBought)), Times.Once);
         }
 
@@ -134,7 +134,7 @@ namespace AutomaticStockTrader.Tests.Stategies
 
             await _strategyHandler.HandleSell(price, strategysStock);
 
-            _mockAlpacaClient.Verify(x => x.PlaceOrder(It.IsAny<StrategysStock>(), It.Is<Order>(x => x.SharesBought == shares * (-1))), Times.Once);
+            _mockAlpacaClient.Verify(x => x.PlaceOrder(It.Is<Order>(x => x.SharesBought == shares * (-1))), Times.Once);
             _mockTrackingRepository.Verify(x => x.AddPendingOrder(It.IsAny<StrategysStock>(), It.Is<Order>(x => x.SharesBought == shares * (-1))), Times.Once);
         }
 
@@ -164,7 +164,7 @@ namespace AutomaticStockTrader.Tests.Stategies
 
             await _strategyHandler.HandleSell(price, strategysStock);
 
-            _mockAlpacaClient.Verify(x => x.PlaceOrder(It.IsAny<StrategysStock>(), It.IsAny<Order>()), Times.Never);
+            _mockAlpacaClient.Verify(x => x.PlaceOrder(It.IsAny<Order>()), Times.Never);
             _mockTrackingRepository.Verify(x => x.AddPendingOrder(It.IsAny<StrategysStock>(), It.IsAny<Order>()), Times.Never);
         }
     }

--- a/AutomaticStockTrader/AutomaticStockTrader.csproj
+++ b/AutomaticStockTrader/AutomaticStockTrader.csproj
@@ -14,13 +14,8 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.Extensions.Configuration" Version="5.0.0" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="5.0.0" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="5.0.0" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="5.0.0" />
     <PackageReference Include="Microsoft.Extensions.Hosting" Version="5.0.0" />
     <PackageReference Include="Microsoft.Extensions.Hosting.Abstractions" Version="5.0.0" />
-    <PackageReference Include="Microsoft.VisualStudio.Azure.Containers.Tools.Targets" Version="1.10.9" />
     <PackageReference Include="System.CommandLine.DragonFruit" Version="0.3.0-alpha.20371.2" />
   </ItemGroup>
 


### PR DESCRIPTION
Get rid of complted order and just let order have stock symbol attached
to it. Also remove alpaca config from the alpaca client. It is no longer
needed. Also remove some usused nuget packages.