### PR TITLE
#9 #32 Add stock reconciliation process

### DIFF
--- a/AutomaticStockTrader.Core/Alpaca/AlpacaClient.cs
+++ b/AutomaticStockTrader.Core/Alpaca/AlpacaClient.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
@@ -108,23 +108,17 @@ namespace AutomaticStockTrader.Core.Alpaca
                     side: order.SharesBought > 0 ? OrderSide.Buy : OrderSide.Sell,
                     type: OrderType.Market,
                     duration: TimeInForce.Ioc));
-        
-
-        /// <summary>
-        /// Clear out any postion that exists
-        /// </summary>
-        public async Task EnsurePostionCleared(StrategysStock postion)
-        {
-            var actualPostion = (await _alpacaTradingClient.ListPositionsAsync()).SingleOrDefault(x => string.Equals(x.Symbol, postion.StockSymbol, StringComparison.OrdinalIgnoreCase));
-            
-            if (actualPostion != null)
-            {
-                await _alpacaTradingClient.PostOrderAsync(new NewOrderRequest(actualPostion.Symbol, actualPostion.Quantity, OrderSide.Sell, OrderType.Market, TimeInForce.Ioc));
-            }
-        }
 
         public async Task<decimal> GetTotalEquity()
             => (await _alpacaTradingClient.GetAccountAsync()).Equity;
+
+        public async Task<IEnumerable<Position>> GetPositions()
+            => (await _alpacaTradingClient.ListPositionsAsync())
+                .Select(x => new Position
+                {
+                    NumberOfShares = x.Quantity,
+                    StockSymbol = x.Symbol
+                });
         
 
         /// <summary>

--- a/AutomaticStockTrader.Core/Alpaca/IAlpacaClient.cs
+++ b/AutomaticStockTrader.Core/Alpaca/IAlpacaClient.cs
@@ -1,4 +1,4 @@
-using AutomaticStockTrader.Domain;
+﻿using AutomaticStockTrader.Domain;
 using System;
 using System.Collections.Generic;
 using System.Threading.Tasks;
@@ -14,6 +14,7 @@ namespace AutomaticStockTrader.Core.Alpaca
         public void SubscribeToTradeUpdates(Action<Order> action);
         public Task PlaceOrder(Order order);
         public Task<decimal> GetTotalEquity();
+        public Task<IEnumerable<Position>> GetPositions();
         public Task<IList<StockInput>> GetStockData(string stockSymbol, TradingFrequency aggUnits, int lookBack = 1000);
         public Task<IEnumerable<DateTime>> GetAllTradingHolidays(DateTime? start = null, DateTime? end = null);
     }

--- a/AutomaticStockTrader.Core/ReconcileStockData.cs
+++ b/AutomaticStockTrader.Core/ReconcileStockData.cs
@@ -1,0 +1,92 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using AutomaticStockTrader.Core.Alpaca;
+using AutomaticStockTrader.Core.Strategies;
+using AutomaticStockTrader.Domain;
+using AutomaticStockTrader.Repository;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
+
+namespace AutomaticStockTrader.Core
+{
+    public class ReconcileStockData : IHostedService
+    {
+        private readonly ILogger<ReconcileStockData> _logger;
+        private readonly IAlpacaClient _alpacaClient;
+        private readonly IEnumerable<StrategyHandler> _strategies;
+        private readonly ITrackingRepository _trackingRepository;
+
+        public ReconcileStockData(
+            ILogger<ReconcileStockData> logger,
+            IAlpacaClient alpacaClient,
+            IEnumerable<StrategyHandler> strategies,
+            ITrackingRepository trackingRepository
+        )
+        {
+            _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+            _alpacaClient = alpacaClient ?? throw new ArgumentNullException(nameof(alpacaClient));
+            _strategies = strategies ?? throw new ArgumentNullException(nameof(strategies));
+            _trackingRepository = trackingRepository ?? throw new ArgumentNullException(nameof(trackingRepository));
+        }
+
+        public async Task StartAsync(CancellationToken cancellationToken)
+        {
+            _logger.LogInformation($"Starting {GetType().Name} job");
+
+            var currentPositions = (await _alpacaClient.GetPositions()).GroupBy(x => x.StockSymbol).Select(x => new Position
+            {
+                StockSymbol = x.Key,
+                NumberOfShares = x.Select(y => y.NumberOfShares).Sum()
+            });
+
+            foreach(var currentPosition in currentPositions)
+            {
+                var strategies = _strategies.Where(x => string.Equals(x.StockStrategy.StockSymbol, currentPosition.StockSymbol, StringComparison.OrdinalIgnoreCase));
+                if (strategies.Any())
+                {
+                    var sharesPerPosition = currentPosition.NumberOfShares / strategies.Count();
+                    
+                    foreach(var strategy in strategies)
+                    {
+                        await ReconcileStock(sharesPerPosition, strategy.StockStrategy);
+                    }
+
+                    var leftoverShares = currentPosition.NumberOfShares % strategies.Count();
+
+                    await ReconcileStock(leftoverShares, strategies.First().StockStrategy);
+                }
+                else
+                {
+                    _logger.LogDebug($"Selling all {currentPosition.NumberOfShares} unneeded shares of {currentPosition.StockSymbol}");
+                    await _alpacaClient.PlaceOrder(new Order
+                    {
+                        OrderPlacedTime = DateTime.UtcNow,
+                        SharesBought = currentPosition.NumberOfShares * (-1),
+                        StockSymbol = currentPosition.StockSymbol
+                    });
+                }
+            }
+
+            _logger.LogInformation($"Finished {GetType().Name} job");
+        }
+
+        private async Task ReconcileStock(long sharesPerPosition, StrategysStock strategy)
+        {
+            _logger.LogDebug($"Assigning {sharesPerPosition} shares of {strategy.StockSymbol} to {strategy.Strategy}");
+
+            var postition = await _trackingRepository.GetOrCreateEmptyPosition(strategy);
+            await _trackingRepository.AddOrder(strategy, new Order
+            {
+                MarketPrice = 0, //This is zero because this strategy did not buy or sell this stock so it should not count for or against it.
+                OrderPlacedTime = DateTime.UtcNow,
+                SharesBought = sharesPerPosition - postition.NumberOfShares,
+            });
+        }
+
+        public Task StopAsync(CancellationToken cancellationToken)
+            => Task.CompletedTask;
+    }
+}

--- a/AutomaticStockTrader.Repository/ITrackingRepository.cs
+++ b/AutomaticStockTrader.Repository/ITrackingRepository.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using System.Collections.Generic;
 using System.Threading.Tasks;
 
@@ -8,6 +8,7 @@ namespace AutomaticStockTrader.Repository
     {
         public Task AddPendingOrder(Domain.StrategysStock postion, Domain.Order order);
         public Task CompleteOrder(Domain.Order completedOrder);
+        public Task AddOrder(Domain.StrategysStock strategysStock, Domain.Order order);
         public Task<Domain.Position> GetOrCreateEmptyPosition(Domain.StrategysStock strategysStock);
         public IEnumerable<Domain.Order> GetCompletedOrders(Domain.StrategysStock strategysStock);
     }

--- a/AutomaticStockTrader.Repository/TrackingRepository.cs
+++ b/AutomaticStockTrader.Repository/TrackingRepository.cs
@@ -1,4 +1,4 @@
-using AutomaticStockTrader.Repository.Models;
+﻿using AutomaticStockTrader.Repository.Models;
 using System;
 using System.Collections.Generic;
 using System.Linq;
@@ -55,6 +55,23 @@ namespace AutomaticStockTrader.Repository
             {
                 Console.WriteLine("Failed to find potential order that matched. Ignoring for now");
             }
+        }
+
+        public async Task AddOrder(Domain.StrategysStock strategysStock, Domain.Order order)
+        {
+            var stratagysStock = GetStatagysStockFromDb(strategysStock);
+
+            _context.Add(new Order
+            {
+                OrderPlaced = order.OrderPlacedTime,
+                AttemptedCostPerShare = order.MarketPrice,
+                AttemptedSharesBought = order.SharesBought,
+                ActualCostPerShare = order.MarketPrice,
+                ActualSharesBought = order.SharesBought,
+                PositionId = stratagysStock.Id
+            });
+
+            await _context.SaveChangesAsync();
         }
 
         public async Task<Domain.Position> GetOrCreateEmptyPosition(Domain.StrategysStock strategysStock)


### PR DESCRIPTION
Add a process to reconcile the shares already in the brokerage account with the shares in the tables. Doing this should also stop the schedule trader from accidently placing a day trad order.

Closes #9 
Closes #32